### PR TITLE
Fix broken internal links and add link checker script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "check-links": "node scripts/check-links.mjs",
+    "check-links:external": "node scripts/check-links.mjs --external"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.2.1",

--- a/scripts/check-links.mjs
+++ b/scripts/check-links.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+/**
+ * Link checker for the Atypical PM site.
+ *
+ * Usage:
+ *   node scripts/check-links.mjs              # Check internal links only
+ *   node scripts/check-links.mjs --external    # Also check external links
+ *
+ * Requires a built site in dist/ — run `pnpm build` first.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join, resolve, dirname } from "node:path";
+import { URL } from "node:url";
+
+const DIST_DIR = resolve(import.meta.dirname, "..", "dist");
+const CHECK_EXTERNAL = process.argv.includes("--external");
+
+async function findHtmlFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findHtmlFiles(full)));
+    } else if (entry.name.endsWith(".html")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function extractLinks(html) {
+  const linkRegex = /<a\s[^>]*href="([^"]*)"[^>]*>/gi;
+  const links = [];
+  let match;
+  while ((match = linkRegex.exec(html)) !== null) {
+    links.push(match[1]);
+  }
+  return links;
+}
+
+async function fileExists(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveInternalLink(href, htmlFilePath) {
+  // Compute the page URL path from the file system path
+  const relativeToDistDir = htmlFilePath
+    .replace(DIST_DIR, "")
+    .replace(/\\/g, "/");
+  // e.g. /what-is-pm/what-is/index.html -> /what-is-pm/what-is/
+  const pageUrl = relativeToDistDir.replace(/index\.html$/, "");
+
+  // Use URL resolution to resolve the href relative to the page URL
+  const base = new URL(pageUrl, "http://localhost");
+  const resolved = new URL(href, base);
+  return resolved.pathname;
+}
+
+async function checkInternalLink(resolvedPath) {
+  // Try the path as-is (file), as directory with index.html, and with .html
+  const candidates = [
+    join(DIST_DIR, resolvedPath),
+    join(DIST_DIR, resolvedPath, "index.html"),
+    join(DIST_DIR, resolvedPath + ".html"),
+  ];
+
+  // If path has trailing slash, also check without it
+  if (resolvedPath.endsWith("/")) {
+    const withoutSlash = resolvedPath.slice(0, -1);
+    candidates.push(
+      join(DIST_DIR, withoutSlash + ".html"),
+      join(DIST_DIR, withoutSlash, "index.html")
+    );
+  }
+
+  for (const candidate of candidates) {
+    if (await fileExists(candidate)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+async function checkExternalLink(url) {
+  try {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10000);
+    const res = await fetch(url, {
+      method: "HEAD",
+      signal: controller.signal,
+      redirect: "follow",
+      headers: { "User-Agent": "AtypicalPM-LinkChecker/1.0" },
+    });
+    clearTimeout(timeout);
+    return { ok: res.ok, status: res.status };
+  } catch (err) {
+    return { ok: false, status: err.message };
+  }
+}
+
+async function main() {
+  const htmlFiles = await findHtmlFiles(DIST_DIR);
+  console.log(`Found ${htmlFiles.length} HTML files in dist/\n`);
+
+  const broken = [];
+  const externalLinks = [];
+
+  for (const file of htmlFiles) {
+    const html = await readFile(file, "utf-8");
+    const links = extractLinks(html);
+    const pagePath = file.replace(DIST_DIR, "").replace(/\\/g, "/");
+
+    for (const href of links) {
+      // Skip anchors, mailto, tel, javascript
+      if (
+        href.startsWith("#") ||
+        href.startsWith("mailto:") ||
+        href.startsWith("tel:") ||
+        href.startsWith("javascript:")
+      ) {
+        continue;
+      }
+
+      if (href.startsWith("http://") || href.startsWith("https://")) {
+        externalLinks.push({ href, page: pagePath });
+        continue;
+      }
+
+      // Internal link
+      const resolved = resolveInternalLink(href, file);
+      const exists = await checkInternalLink(resolved);
+      if (!exists) {
+        broken.push({
+          page: pagePath,
+          href,
+          resolved,
+          type: "internal",
+        });
+      }
+    }
+  }
+
+  // Report internal link results
+  if (broken.length > 0) {
+    console.log(`BROKEN INTERNAL LINKS (${broken.length}):`);
+    console.log("─".repeat(60));
+    for (const b of broken) {
+      console.log(`  Page:     ${b.page}`);
+      console.log(`  Link:     ${b.href}`);
+      console.log(`  Resolves: ${b.resolved}`);
+      console.log("");
+    }
+  } else {
+    console.log("All internal links are valid.");
+  }
+
+  // Check external links if requested
+  if (CHECK_EXTERNAL && externalLinks.length > 0) {
+    console.log(`\nChecking ${externalLinks.length} external links...\n`);
+    const brokenExternal = [];
+
+    for (const { href, page } of externalLinks) {
+      const result = await checkExternalLink(href);
+      if (!result.ok) {
+        brokenExternal.push({ page, href, status: result.status });
+      }
+    }
+
+    if (brokenExternal.length > 0) {
+      console.log(`\nBROKEN EXTERNAL LINKS (${brokenExternal.length}):`);
+      console.log("─".repeat(60));
+      for (const b of brokenExternal) {
+        console.log(`  Page:   ${b.page}`);
+        console.log(`  Link:   ${b.href}`);
+        console.log(`  Status: ${b.status}`);
+        console.log("");
+      }
+    } else {
+      console.log("All external links are valid.");
+    }
+  } else if (!CHECK_EXTERNAL) {
+    console.log(
+      `\nSkipped ${externalLinks.length} external links. Use --external to check them.`
+    );
+  }
+
+  // Exit with error code if any broken links
+  const totalBroken = broken.length;
+  if (totalBroken > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Link checker failed:", err);
+  process.exit(2);
+});

--- a/src/content/docs/pms-job-is/prioritization.mdx
+++ b/src/content/docs/pms-job-is/prioritization.mdx
@@ -38,7 +38,7 @@ In Addition Adam Nash <a href="https://adamnash.blog/2009/07/22/guide-to-product
 
 ## Saying No!
 
-The most common advice given to Product Managers is to say "No" to most requests. Unfortunately it ends there. Saying "No" is easy, in most cases naive, getting all your stake holders to agree to your "No" is what true Product Management is about. This brings us to one of the most important tasks of a PM, building [Leverage](../concepts/leverage)
+The most common advice given to Product Managers is to say "No" to most requests. Unfortunately it ends there. Saying "No" is easy, in most cases naive, getting all your stake holders to agree to your "No" is what true Product Management is about. This brings us to one of the most important tasks of a PM, building [Leverage](../../concepts/leverage)
 
 Saying No requires PMs building leverage for or against the required feature
 

--- a/src/content/docs/pms-job-is/reducing-risk.mdx
+++ b/src/content/docs/pms-job-is/reducing-risk.mdx
@@ -57,7 +57,7 @@ The job-to-be-done wasn't “view data,” it was “manipulate and present data
 When you build the wrong product, you fail before the first line of code ships.
 
 The fix?
-Talk to users early & [often](../pms-job-is/talking-to-customers.mdx)
+Talk to users early & [often](../talking-to-customers)
 Keep asking *why* until the problem becomes painfully clear.
 
 ---
@@ -82,7 +82,7 @@ The problem wasn't importing — it was the friction in cleaning and validating 
 The wrong feature wastes time and dilutes focus.
 The fix?
 Prototype, simulate, and observe.
-Validate *behavior* (a core tenet of [Continuous Discovery](../../pms-job-is/talking-to-customers)), not just *feedback.*
+Validate *behavior* (a core tenet of [Continuous Discovery](../talking-to-customers)), not just *feedback.*
 
 ---
 

--- a/src/content/docs/what-is-pm/what-is.mdx
+++ b/src/content/docs/what-is-pm/what-is.mdx
@@ -14,14 +14,14 @@ Defining what Product Management is very hard, I don't have a concrete answer.
 
 For a long time, I have been trying to build a definition which I like, but I realized, I will never get to it because it is different things at different places and times. Which is why we hear of *zero to one PMs*, *growth PMs*, *process PMs*, Technical PMs, etc. What I have instead, are multiple answers, all of which sound right.
 
-1. [The "Right X" perspective](./my-definitions/right-x)
-2. [Value Driver](./my-definitions/value-driver)
-3. [Problem Solving Function](./my-definitions/problem-solving-function)
+1. [The "Right X" perspective](../my-definitions/right-x)
+2. [Value Driver](../my-definitions/value-driver)
+3. [Problem Solving Function](../my-definitions/problem-solving-function)
 
 Then there are definitions given by veterans of the Industry
 
-- [Shape up by Ryan Singer](../what-is-pm/popular-definitions/shape-up)
-- [A PM is responsible for ensuring that what gets built is both valuable and viable by Marty Cagan](../what-is-pm/popular-definitions/marty-cagan)
+- [Shape up by Ryan Singer](../popular-definitions/shape-up)
+- [A PM is responsible for ensuring that what gets built is both valuable and viable by Marty Cagan](../popular-definitions/marty-cagan)
 
 ## What is the Job of Product Manager
 


### PR DESCRIPTION
Relative links in MDX files resolved incorrectly because trailing-slash
URLs make the browser treat the page slug as a directory. Fixed 8 broken
links across 3 files:
- what-is-pm/what-is.mdx: 5 links (./  should be ../ and redundant path segments)
- pms-job-is/reducing-risk.mdx: 2 links (redundant path + .mdx extension)
- pms-job-is/prioritization.mdx: 1 link (needed extra ../ to reach sibling section)

Added scripts/check-links.mjs to verify all internal links against the
built dist/ directory, with optional --external flag for external URLs.

https://claude.ai/code/session_01LBK2X1YYD5xtAu8B5S3B6e